### PR TITLE
bug/fix-tier-list-filter Don't filter rarity

### DIFF
--- a/.changeset/fix-collection-level-hard-filter.md
+++ b/.changeset/fix-collection-level-hard-filter.md
@@ -1,0 +1,7 @@
+---
+"@mtg-deckbuilder/shared": patch
+"@mtg-deckbuilder/mcp-server": patch
+"@mtg-deckbuilder/electron-app": patch
+---
+
+Fix collection levels (1-4) being used as a hard rarity filter instead of a likelihood hint. `get_collection_filter` baked `r:common OR r:uncommon...` into the generated Scryfall query per set, and the pull list view (`deck_pull_list`) silently dropped any owned-set printing whose rarity exceeded the tracked level — both presented an educated guess about how deeply a user has engaged with a set as certainty about which specific cards they own. `get_collection_filter` now scopes queries by set only (also keeping generated queries well under Scryfall's 500-character limit), while still returning each set's level/rarities as metadata; the pull list now includes higher-rarity printings from owned sets, flagged as lower-confidence rather than excluded.

--- a/packages/mcp-server/src/tools/collection-tools.ts
+++ b/packages/mcp-server/src/tools/collection-tools.ts
@@ -16,14 +16,18 @@ interface CollectionFilterResult {
 }
 
 /**
- * Generates a Scryfall filter string based on the user's set collection.
+ * Generates a Scryfall filter string scoped to the user's tracked set collection.
  *
- * For each set:
- * - Level 4 (Complete): Just the set code, no rarity filter
- * - Levels 1-3: Set code with appropriate rarity filters
+ * Scopes results to owned sets only — no rarity filtering. Each entry's
+ * `collectionLevel` (1-4) and the rarities normally associated with that level
+ * are still returned as `rarities`/`level` metadata: a *hint* for judging how
+ * likely the user is to own a specific printing, not a hard inclusion gate.
+ * A level-1 set's mythic is less likely owned than its common, but it isn't
+ * excluded here — callers combine this with each search result's own `rarity`
+ * to make that judgment themselves.
  *
  * Example output:
- * "(set:mkm) OR (set:one (r:common OR r:uncommon OR r:rare)) OR (set:neo (r:common OR r:uncommon))"
+ * "(set:mkm) OR (set:one) OR (set:neo)"
  */
 export function getCollectionFilter(storage: Storage): CollectionFilterResult {
   const collection = storage.getSetCollection()
@@ -44,22 +48,9 @@ export function getCollectionFilter(storage: Storage): CollectionFilterResult {
     rarities: COLLECTION_LEVEL_RARITIES[entry.collectionLevel]
   }))
 
-  // Build the filter string
-  const filterParts = setFilters.map(setInfo => {
-    if (setInfo.level === 4) {
-      // Complete collection - no rarity filter needed
-      return `(set:${setInfo.setCode})`
-    }
-
-    // Build rarity filter
-    const rarityFilter = setInfo.rarities
-      .map(r => `r:${r}`)
-      .join(' OR ')
-
-    return `(set:${setInfo.setCode} (${rarityFilter}))`
-  })
-
-  const filterString = filterParts.join(' OR ')
+  const filterString = setFilters
+    .map(setInfo => `(set:${setInfo.setCode})`)
+    .join(' OR ')
 
   return {
     filterString,

--- a/packages/mcp-server/src/tools/index.test.ts
+++ b/packages/mcp-server/src/tools/index.test.ts
@@ -1410,7 +1410,7 @@ describe('Collection Filter', () => {
     expect(result.totalSets).toBe(1)
   })
 
-  it('generates rarity-filtered filter for lower levels', async () => {
+  it('scopes by set only regardless of collection level (no rarity gating)', async () => {
     mock._setSetCollection({
       version: 1, updatedAt: '', sets: [{
         setCode: 'one', setName: 'Phyrexia',
@@ -1418,9 +1418,11 @@ describe('Collection Filter', () => {
       }]
     })
     const result = await call('get_collection_filter') as any
-    expect(result.filterString).toContain('r:common')
-    expect(result.filterString).toContain('r:uncommon')
-    expect(result.filterString).not.toContain('r:rare')
+    expect(result.filterString).toBe('(set:one)')
+    expect(result.filterString).not.toContain('r:')
+    // level/rarities still exposed as metadata for the caller's own likelihood judgment
+    expect(result.sets[0].level).toBe(1)
+    expect(result.sets[0].rarities).toEqual(['common', 'uncommon'])
   })
 
   it('joins multiple sets with OR', async () => {

--- a/packages/mcp-server/src/tools/schemas.ts
+++ b/packages/mcp-server/src/tools/schemas.ts
@@ -414,7 +414,7 @@ export function getToolDefinitions(): Tool[] {
     // Collection Filter
     {
       name: 'get_collection_filter',
-      description: 'Generate a Scryfall filter string based on the user\'s set collection. The filter includes sets at their configured collection levels, with appropriate rarity filters. Use this to narrow search results to cards the user likely owns.',
+      description: 'Generate a Scryfall filter string scoped to the sets in the user\'s set collection (set only — no rarity filtering). Each returned set also carries its collection `level` (1-4) and the `rarities` typically associated with that level: a hint for judging ownership likelihood by comparing against each search result\'s own `rarity`, not a hard filter. A card above a set\'s level can still be owned.',
       inputSchema: {
         type: 'object',
         properties: {},

--- a/packages/mcp-server/src/views/index.test.ts
+++ b/packages/mcp-server/src/views/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { renderFullView, renderCurveView, renderNotesView, renderPullListView } from './index.js'
-import { makeDeck, makeDeckCard, makeMockCache, pushMainboard, pushSideboard, pushAlternates } from '../__test__/helpers.js'
+import { makeDeck, makeDeckCard, makeMockCache, mockScryfallCard, pushMainboard, pushSideboard, pushAlternates } from '../__test__/helpers.js'
 import type { Deck, RoleDefinition, ScryfallCard, CardFilter, SetCollectionFile } from '@mtg-deckbuilder/shared'
 import { enrichCards, applyFilters, getMainboard } from '@mtg-deckbuilder/shared'
 
@@ -324,5 +324,65 @@ describe('default/unknown view', () => {
   it('falls back to full view', () => {
     const result = render('nonexistent-view', { name: 'Fallback Test' })
     expect(result).toContain('# Fallback Test')
+  })
+})
+
+describe('pull list view', () => {
+  it("includes a printing whose rarity exceeds its set's tracked collection level, flagged rather than dropped", () => {
+    const deck = makeDeck()
+    pushMainboard(deck, makeDeckCard('Mystic Confluence', {
+      quantity: 1,
+      card: { scryfallId: 'scryfall-mystic-confluence', name: 'Mystic Confluence', setCode: 'grn', collectorNumber: '46' },
+    }))
+
+    const scryfallCache = new Map<string, ScryfallCard>()
+    scryfallCache.set('scryfall-mystic-confluence', mockScryfallCard('Mystic Confluence', {
+      id: 'scryfall-mystic-confluence',
+      set: 'grn',
+      collector_number: '46',
+      rarity: 'rare',
+    }))
+
+    const setCollection: SetCollectionFile = {
+      version: 1, updatedAt: '',
+      sets: [{ setCode: 'grn', setName: 'Guilds of Ravnica', collectionLevel: 1, addedAt: '' }],
+    }
+
+    const result = renderPullListView(deck, setCollection, scryfallCache, { showPulled: true })
+
+    // Previously: a level-1 tracked set silently dropped rare/mythic printings
+    // (the card fell through to "Not in collection" instead of appearing here).
+    expect(result).toContain('Guilds of Ravnica')
+    expect(result).not.toContain('Not in collection')
+    expect(result).toContain('Mystic Confluence')
+    expect(result).toContain('R*')
+    expect(result).toContain('tracked collection level')
+  })
+
+  it("does not flag a printing whose rarity is within its set's tracked collection level", () => {
+    const deck = makeDeck()
+    pushMainboard(deck, makeDeckCard('Opt', {
+      quantity: 1,
+      card: { scryfallId: 'scryfall-opt', name: 'Opt', setCode: 'grn', collectorNumber: '10' },
+    }))
+
+    const scryfallCache = new Map<string, ScryfallCard>()
+    scryfallCache.set('scryfall-opt', mockScryfallCard('Opt', {
+      id: 'scryfall-opt',
+      set: 'grn',
+      collector_number: '10',
+      rarity: 'common',
+    }))
+
+    const setCollection: SetCollectionFile = {
+      version: 1, updatedAt: '',
+      sets: [{ setCode: 'grn', setName: 'Guilds of Ravnica', collectionLevel: 1, addedAt: '' }],
+    }
+
+    const result = renderPullListView(deck, setCollection, scryfallCache, { showPulled: true })
+
+    expect(result).toContain('Opt')
+    expect(result).not.toContain('C*')
+    expect(result).not.toContain('tracked collection level')
   })
 })

--- a/packages/mcp-server/src/views/pull-list-view.ts
+++ b/packages/mcp-server/src/views/pull-list-view.ts
@@ -9,10 +9,12 @@ const RARITY_ORDER: Record<string, number> = {
   'common': 3,
 }
 
-// Check if a rarity is included at a collection level
-function isRarityAvailable(rarity: string, collectionLevel: CollectionLevel): boolean {
-  const allowedRarities = COLLECTION_LEVEL_RARITIES[collectionLevel]
-  return allowedRarities.includes(rarity.toLowerCase())
+// Whether a printing's rarity exceeds what's typically included at a set's
+// tracked collection level. A soft likelihood signal, used only to flag
+// lower-confidence printings — never to exclude them.
+function rarityExceedsCollectionLevel(rarity: string, collectionLevel: CollectionLevel): boolean {
+  const typicalRarities = COLLECTION_LEVEL_RARITIES[collectionLevel]
+  return !typicalRarities.includes(rarity.toLowerCase())
 }
 
 export function renderPullListView(
@@ -122,11 +124,7 @@ export function renderPullListView(
 
     // Get printings from owned sets
     const allPrintings = printingsByName.get(cardName.toLowerCase()) || [cachedCard]
-    const ownedPrintings = allPrintings.filter(p => {
-      if (!ownedSetCodes.has(p.set.toLowerCase())) return false
-      const level = setLevelMap.get(p.set.toLowerCase()) || 1
-      return isRarityAvailable(p.rarity, level)
-    })
+    const ownedPrintings = allPrintings.filter(p => ownedSetCodes.has(p.set.toLowerCase()))
 
     // If no owned printings, show from original set
     if (ownedPrintings.length === 0) {
@@ -156,6 +154,8 @@ export function renderPullListView(
              p.collectorNumber === printing.collector_number
       )?.quantity ?? 0
 
+      const level = setLevelMap.get(printing.set.toLowerCase()) || 1
+
       const item: PullListItem = {
         cardName,
         setCode: printing.set,
@@ -168,7 +168,8 @@ export function renderPullListView(
         quantityNeeded: deckCardQty,
         quantityPulledThisPrint: pulledFromThisPrint,
         quantityPulledTotal: totalPulled,
-        remainingNeeded
+        remainingNeeded,
+        rarityAboveCollectionLevel: rarityExceedsCollectionLevel(printing.rarity, level)
       }
 
       if (remainingNeeded > 0) {
@@ -229,9 +230,16 @@ export function renderPullListView(
       for (const item of group.items) {
         const primaryType = item.typeLine.split(' ')[0] || 'Unknown'
         const rarityShort = item.rarity[0]?.toUpperCase() || '?'
+        const rarityCell = item.rarityAboveCollectionLevel ? `${rarityShort}*` : rarityShort
         const status = `${item.quantityPulledTotal}/${item.quantityNeeded}`
-        lines.push(`| ${item.collectorNumber} | ${rarityShort} | ${primaryType} | ${item.manaCost} | ${item.cardName} | ${status} |`)
+        lines.push(`| ${item.collectorNumber} | ${rarityCell} | ${primaryType} | ${item.manaCost} | ${item.cardName} | ${status} |`)
       }
+
+      if (group.items.some(i => i.rarityAboveCollectionLevel)) {
+        lines.push('')
+        lines.push("_\\* rarity exceeds this set's tracked collection level — may not be owned; treat as lower-confidence._")
+      }
+
       lines.push('')
     }
   } else {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -570,6 +570,13 @@ export interface PullListItem {
   quantityPulledThisPrint: number
   quantityPulledTotal: number
   remainingNeeded: number
+  /**
+   * True when this printing's rarity exceeds what's typically included at
+   * the owning set's tracked collection level (e.g. a mythic pulled from a
+   * set tracked at level 1). A soft ownership-likelihood signal, not a
+   * filter — the printing still appears either way.
+   */
+  rarityAboveCollectionLevel?: boolean
 }
 
 export interface PullListGroup {

--- a/skills/mtg-deckbuilder-lookup/SKILL.md
+++ b/skills/mtg-deckbuilder-lookup/SKILL.md
@@ -60,21 +60,26 @@ search_cards  query="function:counterspell-noncreature game:paper"
 
 (For the `game:paper` convention and other operators, see **scryfall-search**.)
 
-## `get_collection_filter` — narrow to owned cards
+## `get_collection_filter` — scope to owned sets, judge likelihood yourself
 
-Returns a Scryfall filter string composed from the user's tracked collection (per-set rarity inclusion based on collection levels). Use it to constrain `search_cards` results to cards the user is likely to own.
+Returns a Scryfall filter string scoped to the sets in the user's tracked collection — set only, no rarity gating. Each set also comes back with its `level` (1-4) and the `rarities` typically associated with that level. Use the filter to scope `search_cards` to owned sets; use `level` plus each result's own `rarity` field as a **soft signal** for how likely the user is to own a specific card — never as a hard include/exclude. A set tracked at level 1 ("a few packs") still contains real rares and mythics; a few packs guarantee several rare-slot pulls, just not any *specific* rare. Don't drop higher-rarity cards from a lower-level set — surface them, flagged as less certain.
 
 ```
 1. get_collection_filter
-   → returns e.g. "(s:dmu r<=r OR s:lci r<=r OR s:mh3 r<=m)"
+   → filterString: "(set:dmu) OR (set:lci) OR (set:mh3)"
+     sets: [
+       { setCode: "dmu", level: 1, rarities: ["common","uncommon"] },
+       { setCode: "lci", level: 2, rarities: ["common","uncommon","rare"] },
+       { setCode: "mh3", level: 3, rarities: ["common","uncommon","rare","mythic"] }
+     ]
 
-2. search_cards  query="<collection_filter> c:g function:ramp mv<=2"
-   → only green 2-mana ramp from owned sets
+2. search_cards  query="<filterString> c:g function:ramp mv<=2"
+   → green 2-mana ramp from those sets, each result carrying its own `rarity`
 ```
 
-Note: this filter reflects the user's *tracked* collection (set-level granularity with rarity levels), not their literal owned cards. It's a useful approximation, not a guarantee.
+**Judging likelihood:** compare each result's `rarity` against its set's `level`/`rarities`. A card whose rarity is covered by the set's `rarities` is likely owned; a card whose rarity exceeds it (e.g. a mythic from a set tracked at level 1) is less likely owned but still real — present it, flagged, don't drop it from the results.
 
-**Query length ceiling:** combining `get_collection_filter`'s output with additional filters can push a query past Scryfall's hard 500-character limit — common once a tracked collection spans many sets. See the **scryfall-search** skill's "Query length limit" section for the cause and mitigation (splitting into multiple searches, avoiding per-set/per-card `OR`-chains).
+Because the filter is set-only, it's typically well under Scryfall's 500-character query limit even for large collections — see the **scryfall-search** skill's "Query length limit" section if you still hit it after combining with many other filters.
 
 ### Collection levels — what each level means
 
@@ -85,7 +90,7 @@ Note: this filter reflects the user's *tracked* collection (set-level granularit
 | 3 | + mythics |
 | 4 | All cards including special / promo rarities |
 
-Configured per-set in the user's collection config. `get_collection_filter` returns the union across all configured sets.
+Configured per-set in the user's collection config. `get_collection_filter` returns the union across all configured sets. Treat these as typical rarities for that engagement level, not a ceiling — see "Judging likelihood" above.
 
 ## Worked workflows
 
@@ -102,10 +107,15 @@ Configured per-set in the user's collection config. `get_collection_filter` retu
 
 ```
 1. get_collection_filter
-   → collection_filter string
+   → filterString scoped to owned sets, sets[] with level + rarities
 
-2. search_cards  query="<collection_filter> function:tutor-any id<=wub f:commander", limit=25
-   → owned generic tutors in Esper identity
+2. search_cards  query="<filterString> function:tutor-any id<=wub f:commander", limit=25
+   → tutors from owned sets in Esper identity, each with its own `rarity`
+
+3. For each result, compare its `rarity` to its set's tracked `level`/`rarities`
+   from step 1 — present commons/uncommons from a level-1 set as likely owned,
+   flag a rare/mythic from that same set as possible-but-unconfirmed rather
+   than omitting it.
 ```
 
 ### "Quickly look up Sol Ring"

--- a/skills/scryfall-search/SKILL.md
+++ b/skills/scryfall-search/SKILL.md
@@ -215,7 +215,7 @@ game:arena -game:paper is:digital
 
 Scryfall enforces a **hard 500-character ceiling** on a single query string. Queries over the limit are rejected, not truncated.
 
-**Why it bites deck-building queries specifically:** the usual way to blow past it is a large `OR`-chain — most often one `set:` clause per owned set, e.g. the output of `get_collection_filter` (`(s:dmu r<=r OR s:lci r<=r OR s:mh3 r<=m OR ...)`). A tracked collection spanning 20+ sets can exceed 500 characters before any other filter is even added.
+**Why it bites deck-building queries specifically:** the usual way to blow past it is a large `OR`-chain — most often one `set:` clause per owned set, e.g. the output of `get_collection_filter` (`(set:dmu) OR (set:lci) OR (set:mh3) OR ...`). `get_collection_filter` scopes by set only (no rarity clauses baked in), so a single collection-scoped chain is much shorter than a per-rarity one — but a tracked collection spanning 30+ sets, or combining the chain with several other filters, can still add up. Watch total query length whenever you concatenate a set-scoped `OR`-chain with additional operators.
 
 **Mitigation:**
 - Prefer compact operators over enumerating values — `r<=u` instead of `(r:c OR r:u)`.


### PR DESCRIPTION
Tier list was never meant to hard filter on rarity. This commit removes that filtering